### PR TITLE
fix(backend): resolve Cloud Run container startup issues

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,16 +4,19 @@ FROM node:20-alpine
 # Set working directory
 WORKDIR /app
 
-# Install dependencies for better performance
+# Install dependencies for better performance and native modules
 RUN apk add --no-cache \
     dumb-init \
+    python3 \
+    make \
+    g++ \
     && rm -rf /var/cache/apk/*
 
 # Copy package files
 COPY package*.json ./
 
-# Install production dependencies
-RUN npm ci --only=production && npm cache clean --force
+# Install dependencies with proper flags
+RUN npm ci --omit=dev && npm cache clean --force
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
@@ -30,7 +33,7 @@ USER nodejs
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node healthcheck.js || exit 1
 
-# Expose port
+# Expose port (matches Cloud Run configuration)
 EXPOSE 3001
 
 # Use dumb-init to handle signals properly

--- a/backend/healthcheck.js
+++ b/backend/healthcheck.js
@@ -1,14 +1,20 @@
-import http from 'http';
+#!/usr/bin/env node
+/**
+ * Healthcheck script for Cloud Run deployment
+ * Checks if the server is responding on the expected port
+ */
 
+const http = require('http');
+
+const PORT = process.env.PORT || 3001;
 const options = {
-  host: 'localhost',
-  port: process.env.PORT || 3001,
+  host: '0.0.0.0',
+  port: PORT,
   timeout: 2000,
-  method: 'GET',
   path: '/api/health'
 };
 
-const request = http.request(options, (res) => {
+const healthCheck = http.request(options, (res) => {
   console.log(`Health check status: ${res.statusCode}`);
   if (res.statusCode === 200) {
     process.exit(0);
@@ -17,9 +23,14 @@ const request = http.request(options, (res) => {
   }
 });
 
-request.on('error', (err) => {
-  console.error('Health check failed:', err.message);
+healthCheck.on('error', (error) => {
+  console.error('Health check failed:', error.message);
   process.exit(1);
 });
 
-request.end();
+healthCheck.on('timeout', () => {
+  console.error('Health check timeout');
+  process.exit(1);
+});
+
+healthCheck.end();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -33,7 +33,7 @@ const io = new Server(server, {
   }
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 3001;
 
 // Base de données
 mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/auramatch')
@@ -106,10 +106,10 @@ app.use('*', (req, res) => {
   });
 });
 
-server.listen(PORT, () => {
+server.listen(PORT, '0.0.0.0', () => {
   console.log(`🚀 Serveur AuraMatch démarré sur le port ${PORT}`);
-  console.log(`🌐 URL: http://localhost:${PORT}`);
-  console.log(`📝 Documentation API: http://localhost:${PORT}/api/health`);
+  console.log(`🌐 URL: http://0.0.0.0:${PORT}`);
+  console.log(`📝 Documentation API: http://0.0.0.0:${PORT}/api/health`);
 });
 
 export default app;


### PR DESCRIPTION
- Fix server to listen on 0.0.0.0 instead of localhost for Cloud Run compatibility
- Align PORT configuration: server.js defaults to 3001 (matches Cloud Run --port 3001)
- Add proper healthcheck.js file for Docker health checks
- Update Dockerfile with build dependencies (python3, make, g++) for native modules
- Use npm ci --omit=dev for production dependencies only
- Ensures container starts and responds to Cloud Run health checks properly

Fixes: Container failed to start and listen on PORT error in Cloud Run